### PR TITLE
Bug fix: prevent History notes layout overflow and add session deletion

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@
 
 import os
 
-from flask import Flask, render_template, request, redirect, url_for, jsonify
+from flask import Flask, render_template, request, redirect, url_for, jsonify, abort
 from flask_login import LoginManager, login_user, logout_user, login_required, current_user
 from flask_migrate import Migrate
 from models import db, ExerciseSession, SessionExercise, User, Share, Friend
@@ -276,7 +276,6 @@ def history():
             "date": session.date,
             "current_weight": session.current_weight,
             "total_calories": session.total_calories,
-            "notes": session.notes,
             "latitude": session.latitude,
             "longitude": session.longitude
         }
@@ -284,6 +283,20 @@ def history():
         if session.latitude is not None and session.longitude is not None
     ]
     return render_template("history.html", username=current_user.username, sessions=sessions, location_data=location_data)
+
+@app.route("/history/<int:session_id>/delete", methods=["POST"])
+@login_required
+def delete_session(session_id):
+    session = db.session.get(ExerciseSession, session_id)
+
+    if session is None or session.user_id != current_user.id:
+        abort(404)
+
+    Share.query.filter_by(session_id=session.id).delete()
+    db.session.delete(session)
+    db.session.commit()
+
+    return redirect(url_for("history"))
     
 @app.route("/", methods = ["GET", "POST"])
 @app.route("/login", methods = ["GET", "POST"])

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -258,6 +258,24 @@ body {
   overflow: hidden;
 }
 
+.history-table {
+  table-layout: fixed;
+  width: 100%;
+}
+
+.history-notes {
+  width: 35%;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.history-map .leaflet-popup-content {
+  max-width: 240px;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 .activity-map .leaflet-pane,
 .activity-map .leaflet-top,
 .activity-map .leaflet-bottom,

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -265,6 +265,12 @@ body {
 
 .history-notes {
   width: 35%;
+}
+
+.history-notes-box {
+  max-height: 96px;
+  overflow-y: auto;
+  padding-right: 0.25rem;
   white-space: normal;
   overflow-wrap: anywhere;
   word-break: break-word;

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -169,7 +169,7 @@ function initHistoryLocationMap() {
       <strong>${escapeHtml(session.date)}</strong><br>
       Calories: ${escapeHtml(session.total_calories)} kcal<br>
       Weight: ${escapeHtml(session.current_weight)} kg<br>
-      Notes: ${escapeHtml(session.notes || "-")}
+      Location: ${formatCoordinate(latitude)}, ${formatCoordinate(longitude)}
     `).openPopup();
 
     historyMap.setView([latitude, longitude], 15);

--- a/templates/history.html
+++ b/templates/history.html
@@ -53,7 +53,9 @@
                                 Not recorded
                                 {% endif %}
                             </td>
-                            <td class="history-notes">{{ session.notes or '-' }}</td>
+                            <td class="history-notes">
+                                <div class="history-notes-box">{{ session.notes or '-' }}</div>
+                            </td>
                             <td>
                                 <form method="POST" action="{{ url_for('delete_session', session_id=session.id) }}" onsubmit="return confirm('Delete this session?');">
                                     <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>

--- a/templates/history.html
+++ b/templates/history.html
@@ -25,7 +25,7 @@
             </div>
 
             <div class="table-responsive">
-                <table class="table table-striped align-middle">
+                <table class="table table-striped align-middle history-table">
                     <thead>
                         <tr>
                             <th>Date</th>
@@ -33,6 +33,7 @@
                             <th>Total Calories</th>
                             <th>Location</th>
                             <th>Notes</th>
+                            <th>Action</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -52,7 +53,12 @@
                                 Not recorded
                                 {% endif %}
                             </td>
-                            <td>{{ session.notes or '-' }}</td>
+                            <td class="history-notes">{{ session.notes or '-' }}</td>
+                            <td>
+                                <form method="POST" action="{{ url_for('delete_session', session_id=session.id) }}" onsubmit="return confirm('Delete this session?');">
+                                    <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
+                                </form>
+                            </td>
                         </tr>
                         {% endfor %}
                     </tbody>


### PR DESCRIPTION
This PR fixes the History page layout issue where long notes could stretch the table horizontally, adds a Delete button so users can remove sessions entered by mistake, and removes notes from the activity location map popup to prevent oversized popup text. The delete route only allows users to delete their own sessions and also cleans up related exercises and shares so the database stays consistent.