### PR TITLE
Adjust ranking to focus on calories burned

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from flask_migrate import Migrate
 from models import db, ExerciseSession, SessionExercise, User, Share, Friend
 from data import exercise_data
 from utils import calculate_calories
-from datetime import date as current_date
+from datetime import date as current_date, timedelta
 from werkzeug.utils import secure_filename
 
 app = Flask(__name__)
@@ -248,27 +248,44 @@ def check_username():
 @app.route("/ranking")
 @login_required
 def ranking():
+    period_options = {
+        "all": ("All Time", None),
+        "daily": ("Daily", 0),
+        "weekly": ("Weekly", 6),
+        "monthly": ("Monthly", 29),
+        "half_year": ("Half Yearly", 182)
+    }
+    selected_period = request.args.get("period", "all")
+    if selected_period not in period_options:
+        selected_period = "all"
+
+    today = current_date.today()
+    period_label, days_back = period_options[selected_period]
+    start_date = None if days_back is None else (today - timedelta(days=days_back)).isoformat()
+    end_date = today.isoformat()
+
     users = User.query.all()
     ranking_data = []
 
     for user in users:
         sessions = ExerciseSession.query.filter_by(user_id=user.id).order_by(ExerciseSession.date.asc()).all()
-        latest_session = sessions[-1] if sessions else None
-        total_calories = sum(session.total_calories for session in sessions)
-        kg_lost = 0
-
-        if user.weight is not None and latest_session is not None:
-            kg_lost = user.weight - latest_session.current_weight
+        filtered_sessions = [
+            session for session in sessions
+            if start_date is None or (start_date <= session.date <= end_date)
+        ]
+        total_calories = sum(session.total_calories for session in filtered_sessions)
 
         ranking_data.append({
             "username": user.username,
-            "kg_lost": round(kg_lost, 1),
             "total_calories": round(total_calories, 2),
-            "total_sessions": len(sessions)
+            "total_sessions": len(filtered_sessions),
+            "has_sessions": len(filtered_sessions) > 0
         })
 
-    ranking_data.sort(key=lambda item: (item["kg_lost"], item["total_calories"]), reverse=True)
-    return render_template("ranking.html", username=current_user.username, ranking_data=ranking_data)
+    ranking_data.sort(key=lambda item: (item["has_sessions"], item["total_calories"]), reverse=True)
+    return render_template("ranking.html", username=current_user.username, ranking_data=ranking_data,
+                           period_options=period_options, selected_period=selected_period,
+                           period_label=period_label)
 
 @app.route("/history")
 @login_required

--- a/templates/ranking.html
+++ b/templates/ranking.html
@@ -10,8 +10,19 @@
     <div class="container py-4">
         <div class="main-box">
             <h1>Ranking</h1>
-            <p class="text-muted">Compare users by weight change and total calories burned.</p>
+            <p class="text-muted">Compare users by total calories burned from saved exercise sessions.</p>
             <hr>
+
+            <div class="d-flex flex-wrap gap-2 mb-3">
+                {% for value, option in period_options.items() %}
+                    <a href="{{ url_for('ranking', period=value) }}"
+                       class="btn btn-sm {{ 'btn-primary' if selected_period == value else 'btn-outline-primary' }}">
+                        {{ option[0] }}
+                    </a>
+                {% endfor %}
+            </div>
+
+            <p class="text-muted">Showing {{ period_label|lower }} results. Users with no sessions in this period are placed after users with saved session data.</p>
 
             {% if ranking_data %}
             <div class="table-responsive">
@@ -20,7 +31,6 @@
                         <tr>
                             <th>Rank</th>
                             <th>User</th>
-                            <th>Kg Lost</th>
                             <th>Total Calories</th>
                             <th>Sessions</th>
                         </tr>
@@ -30,7 +40,6 @@
                         <tr>
                             <td>{{ loop.index }}</td>
                             <td>{{ user.username }}</td>
-                            <td>{{ user.kg_lost }}</td>
                             <td>{{ user.total_calories }}</td>
                             <td>{{ user.total_sessions }}</td>
                         </tr>


### PR DESCRIPTION
Thanks for pointing this out. I agree that the ranking page update and the CSRF protection should be reviewed separately.I have updated this PR so it only includes the ranking page change related to issue #52.The CSRF protection changes have been removed from this PR and will be kept for a separate PR later, after the main page flows are more stable. This PR now only updates the ranking logic to focus on total calories burned, removes the confusing kg lost ranking column, and adds time filters for all time, daily, weekly, monthly, and half yearly views.
