### PR TITLE
Add history session sharing

### DIFF
--- a/app.py
+++ b/app.py
@@ -291,6 +291,10 @@ def ranking():
 @login_required
 def history():
     sessions = ExerciseSession.query.filter_by(user_id=current_user.id).order_by(ExerciseSession.date.desc()).all()
+    friends = User.query.join(Friend, (
+        ((Friend.sender_id == current_user.id) & (Friend.receiver_id == User.id)) |
+        ((Friend.receiver_id == current_user.id) & (Friend.sender_id == User.id))
+    )).filter(Friend.status == "accepted").all()
     location_data = [
         {
             "id": session.id,
@@ -303,7 +307,8 @@ def history():
         for session in sessions
         if session.latitude is not None and session.longitude is not None
     ]
-    return render_template("history.html", username=current_user.username, sessions=sessions, location_data=location_data)
+    return render_template("history.html", username=current_user.username, sessions=sessions,
+                           location_data=location_data, friends=friends)
 
 @app.route("/history/<int:session_id>/delete", methods=["POST"])
 @login_required

--- a/templates/history.html
+++ b/templates/history.html
@@ -57,14 +57,56 @@
                                 <div class="history-notes-box">{{ session.notes or '-' }}</div>
                             </td>
                             <td>
-                                <form method="POST" action="{{ url_for('delete_session', session_id=session.id) }}" onsubmit="return confirm('Delete this session?');">
-                                    <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
-                                </form>
+                                <div class="d-flex gap-2 flex-wrap">
+                                    <button type="button"
+                                            class="btn-pink btn-sm history-share-btn"
+                                            data-bs-toggle="modal"
+                                            data-bs-target="#historyShareModal"
+                                            data-session-id="{{ session.id }}"
+                                            data-session-date="{{ session.date }}">
+                                        Share
+                                    </button>
+                                    <form method="POST" action="{{ url_for('delete_session', session_id=session.id) }}" onsubmit="return confirm('Delete this session?');">
+                                        <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
+                                    </form>
+                                </div>
                             </td>
                         </tr>
                         {% endfor %}
                     </tbody>
                 </table>
+            </div>
+
+            <div class="modal fade" id="historyShareModal" tabindex="-1">
+                <div class="modal-dialog">
+                    <div class="modal-content">
+                        <div class="modal-header">
+                            <h5 class="modal-title">Share this session</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                        </div>
+                        <form method="POST" action="{{ url_for('forum') }}">
+                            <input type="hidden" name="action" value="share">
+                            <input type="hidden" name="session_id" id="historyShareSessionId">
+                            <div class="modal-body">
+                                <p class="text-muted" id="historyShareSessionLabel">Select a friend to share this session with.</p>
+                                <label class="form-label fw-bold">Share with</label>
+                                <select name="receiver_id" class="form-select" required>
+                                    <option value="">- select a friend -</option>
+                                    {% for f in friends %}
+                                    <option value="{{ f.id }}">{{ f.username }}</option>
+                                    {% endfor %}
+                                </select>
+                                {% if not friends %}
+                                <p class="text-muted mt-2" style="font-size: 0.85rem;">You have no friends yet. Add some from the Account page.</p>
+                                {% endif %}
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                                <button type="submit" class="btn-pink" {% if not friends %}disabled{% endif %}>Share</button>
+                            </div>
+                        </form>
+                    </div>
+                </div>
             </div>
             {% else %}
             <div class="alert alert-info mb-0">
@@ -78,6 +120,12 @@
 {% block scripts %}
     <script>
         window.historyLocations = {{ location_data | tojson }};
+        document.querySelectorAll(".history-share-btn").forEach((button) => {
+            button.addEventListener("click", () => {
+                document.getElementById("historyShareSessionId").value = button.dataset.sessionId;
+                document.getElementById("historyShareSessionLabel").textContent = `Share session from ${button.dataset.sessionDate}.`;
+            });
+        });
     </script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="{{ url_for('static', filename='js/map.js') }}"></script>


### PR DESCRIPTION
This PR adds a Share button to the History page so users can share saved exercise sessions after they have already been created.
Previously, users could only share a session immediately after adding it from the Exercise page. This update makes sharing more consistent by allowing users to share any saved session directly from their History page.  Each history record now shows a Share button before the Delete button. When clicked, it opens a popup modal where the user can select an accepted friend. The History page reuses the existing sharing flow by submitting to the current `/forum` share logic with the selected session and receiver. No separate sharing backend was added. If the user has no accepted friends, the modal shows a message telling them to add friends from the Account page, and the Share button inside the modal is disabled.I tested that the History page renders correctly, the Share modal appears, accepted friends are available in the selector, and submitting the form successfully creates a Share record.
