### PR TITLE
Show user profile pictures across ranking and social views

### DIFF
--- a/app.py
+++ b/app.py
@@ -51,6 +51,26 @@ def parse_location_fields(latitude_raw, longitude_raw):
 
     return latitude, longitude, None
 
+def user_avatar_url(user):
+    if not user or not user.avatar:
+        return None
+
+    avatar_path = os.path.join(app.root_path, "static", "uploads", user.avatar)
+    if not os.path.isfile(avatar_path):
+        return None
+
+    return url_for("static", filename="uploads/" + user.avatar)
+
+@app.context_processor
+def inject_avatar_helpers():
+    return {"user_avatar_url": user_avatar_url}
+
+def user_avatar_payload(user):
+    return {
+        "username": user.username,
+        "avatar_url": user_avatar_url(user)
+    }
+
 @app.route("/dashboard/ai-feedback", methods=["POST"])
 @login_required
 def dashAiFeedback():
@@ -359,6 +379,7 @@ def ranking():
 
         ranking_data.append({
             "username": user.username,
+            "avatar_url": user_avatar_url(user),
             "total_calories": round(total_calories, 2),
             "total_sessions": len(filtered_sessions),
             "has_sessions": len(filtered_sessions) > 0
@@ -580,7 +601,7 @@ def search_users():
         User.username != current_user.username
     ).limit(10).all()
 
-    result = [{"username": u.username} for u in users]
+    result = [user_avatar_payload(u) for u in users]
 
     return jsonify(result)
 
@@ -650,7 +671,7 @@ def get_friends():
     for r in pending_reqs:
         sender = User.query.get(r.sender_id)
         if sender:
-            pending.append(sender.username)
+            pending.append(user_avatar_payload(sender))
 
     # find all accepted relationships
     relations = Friend.query.filter_by(status="accepted").all()
@@ -663,17 +684,17 @@ def get_friends():
         if r.sender_id == user_id:
             u = User.query.get(r.receiver_id)
             if u:
-                friends.append(u.username)
+                friends.append(user_avatar_payload(u))
 
         # current user is receiver → friend is sender
         elif r.receiver_id == user_id:
             u = User.query.get(r.sender_id)
             if u:
-                friends.append(u.username)
+                friends.append(user_avatar_payload(u))
 
     # sort lists for stable display
-    pending.sort()
-    friends.sort()
+    pending.sort(key=lambda item: item["username"].lower())
+    friends.sort(key=lambda item: item["username"].lower())
 
     # return result for frontend
     return jsonify({

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -733,6 +733,38 @@ body {
   color: #333333;
 }
 
+/* Shared user avatars */
+
+.user-avatar-small {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex: 0 0 32px;
+}
+
+.user-avatar-fallback {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: #6c757d;
+  color: #ffffff;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.ranking-user,
+.shared-user-line,
+.account-user-line {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.shared-user-line + .shared-user-line {
+  margin-top: 0.35rem;
+}
+
 /* Account page */
 
 .account-page .main-box {

--- a/templates/account.html
+++ b/templates/account.html
@@ -60,8 +60,9 @@
 </div>
 
 <div class="col-md-3 text-center">
-{% if user.avatar %}
-<img src="{{ url_for('static', filename='uploads/' + user.avatar) }}" class="avatar-preview">
+{% set profile_avatar_url = user_avatar_url(user) %}
+{% if profile_avatar_url %}
+<img src="{{ profile_avatar_url }}" class="avatar-preview">
 {% else %}
 <div class="avatar-placeholder">{{ user.username[0]|upper }}</div>
 {% endif %}
@@ -306,6 +307,30 @@ if(type==="add"){
 let pending=[ ];
 let friends=[ ];
 
+function avatarNode(user){
+const avatar = document.createElement(user.avatar_url ? "img" : "span");
+avatar.className = user.avatar_url ? "user-avatar-small" : "user-avatar-small user-avatar-fallback";
+if(user.avatar_url){
+avatar.src = user.avatar_url;
+avatar.alt = user.username;
+} else {
+avatar.textContent = user.username ? user.username[0].toUpperCase() : "?";
+}
+return avatar;
+}
+
+function userLine(user){
+const wrapper = document.createElement("div");
+wrapper.className = "account-user-line";
+wrapper.appendChild(avatarNode(user));
+
+const name = document.createElement("span");
+name.textContent = user.username;
+wrapper.appendChild(name);
+
+return wrapper;
+}
+
 function searchUsers(){
 const keyword=document.getElementById("searchInput").value;
 if(!keyword.trim()) return;
@@ -331,17 +356,19 @@ list.forEach(u=>{
 
     const row = document.createElement("div");
     row.className="d-flex justify-content-between border-bottom py-2";
+    row.appendChild(userLine(u));
 
-    row.innerHTML=`
-    <span>${username}</span>
-    <button class="btn btn-save btn-sm" onclick="addFriend('${username}')">Add</button>
-    `;
+    const button = document.createElement("button");
+    button.className = "btn btn-save btn-sm";
+    button.textContent = "Add";
+    button.addEventListener("click", () => addFriend(username, button));
+    row.appendChild(button);
 
     box.appendChild(row);
 });
 }
 
-function addFriend(username){
+function addFriend(username, button){
 fetch('/api/add_friend',{
 method:'POST',
 headers:{'Content-Type':'application/json'},
@@ -351,21 +378,15 @@ body:JSON.stringify({username:username})
 .then(data => {
     alert(data.message);
 
-    const buttons = document.querySelectorAll("button");
+    if(button && data.message === "request sent"){
+        button.innerText = "Requested";
+        button.disabled = true;
+    }
 
-    buttons.forEach(btn=>{
-        if(btn.getAttribute("onclick")?.includes(`'${username}'`)){
-
-            if(data.message === "request sent"){
-                btn.innerText = "Requested";
-            }
-
-            if(data.message === "friend added"){
-                btn.innerText = "Friends";
-            }
-
-        }
-    });
+    if(button && data.message === "friend added"){
+        button.innerText = "Friends";
+        button.disabled = true;
+    }
 
     loadFriends();
 });
@@ -378,14 +399,23 @@ box.innerHTML="";
 pending.forEach(u=>{
 const row=document.createElement("div");
 row.className="d-flex justify-content-between border-bottom py-2";
+row.appendChild(userLine(u));
 
-row.innerHTML=`
-<span>${u}</span>
-<div>
-<button class="btn btn-success btn-sm" onclick="acceptFriend('${u}')">Accept</button>
-<button class="btn btn-danger btn-sm" onclick="rejectFriend('${u}')">Reject</button>
-</div>
-`;
+const actions = document.createElement("div");
+
+const accept = document.createElement("button");
+accept.className = "btn btn-success btn-sm";
+accept.textContent = "Accept";
+accept.addEventListener("click", () => acceptFriend(u.username));
+
+const reject = document.createElement("button");
+reject.className = "btn btn-danger btn-sm ms-2";
+reject.textContent = "Reject";
+reject.addEventListener("click", () => rejectFriend(u.username));
+
+actions.appendChild(accept);
+actions.appendChild(reject);
+row.appendChild(actions);
 
 box.appendChild(row);
 });
@@ -427,7 +457,7 @@ box.innerHTML="";
 friends.forEach(u=>{
 const row=document.createElement("div");
 row.className="border-bottom py-2";
-row.innerText=u;
+row.appendChild(userLine(u));
 box.appendChild(row);
 });
 }

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -24,7 +24,28 @@
                     <div class = "post-card">
                         <div class = "post-meta">
                             <div class = "post-date">{{ share.session.date }}</div>
-                            <div class = "post-from-to">From: Me<br>To: {{share.receiver.username}}</div>
+                            <div class = "post-from-to">
+                                <div class="shared-user-line">
+                                    <span>From:</span>
+                                    {% set current_avatar_url = user_avatar_url(current_user) %}
+                                    {% if current_avatar_url %}
+                                        <img src="{{ current_avatar_url }}" class="user-avatar-small" alt="{{ current_user.username }}">
+                                    {% else %}
+                                        <span class="user-avatar-small user-avatar-fallback">{{ current_user.username[0]|upper }}</span>
+                                    {% endif %}
+                                    <span>Me</span>
+                                </div>
+                                <div class="shared-user-line">
+                                    <span>To:</span>
+                                    {% set receiver_avatar_url = user_avatar_url(share.receiver) %}
+                                    {% if receiver_avatar_url %}
+                                        <img src="{{ receiver_avatar_url }}" class="user-avatar-small" alt="{{ share.receiver.username }}">
+                                    {% else %}
+                                        <span class="user-avatar-small user-avatar-fallback">{{ share.receiver.username[0]|upper }}</span>
+                                    {% endif %}
+                                    <span>{{ share.receiver.username }}</span>
+                                </div>
+                            </div>
                         </div>
                         <div class = "post-divider"></div>
                         <div class = "flex-grow-1">
@@ -53,7 +74,28 @@
                     <div class = "post-card">
                         <div class = "post-meta">
                             <div class = "post-date">{{ share.session.date }}</div>
-                            <div class = "post-from-to">From: {{share.sender.username}}<br>To: Me</div>
+                            <div class = "post-from-to">
+                                <div class="shared-user-line">
+                                    <span>From:</span>
+                                    {% set sender_avatar_url = user_avatar_url(share.sender) %}
+                                    {% if sender_avatar_url %}
+                                        <img src="{{ sender_avatar_url }}" class="user-avatar-small" alt="{{ share.sender.username }}">
+                                    {% else %}
+                                        <span class="user-avatar-small user-avatar-fallback">{{ share.sender.username[0]|upper }}</span>
+                                    {% endif %}
+                                    <span>{{ share.sender.username }}</span>
+                                </div>
+                                <div class="shared-user-line">
+                                    <span>To:</span>
+                                    {% set current_avatar_url = user_avatar_url(current_user) %}
+                                    {% if current_avatar_url %}
+                                        <img src="{{ current_avatar_url }}" class="user-avatar-small" alt="{{ current_user.username }}">
+                                    {% else %}
+                                        <span class="user-avatar-small user-avatar-fallback">{{ current_user.username[0]|upper }}</span>
+                                    {% endif %}
+                                    <span>Me</span>
+                                </div>
+                            </div>
                         </div>
                         <div class = "post-divider"></div>
                         <div class = "flex-grow-1">

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -10,8 +10,9 @@
     <div class = "ep-nav-spacer"></div>
     <div class = "ep-user-menu">
         <div class="ep-user-avatar">
-            {% if current_user.avatar %}
-                <img src="{{ url_for('static', filename='uploads/' + current_user.avatar) }}"
+            {% set nav_avatar_url = user_avatar_url(current_user) %}
+            {% if nav_avatar_url %}
+                <img src="{{ nav_avatar_url }}"
                     style="width:100%;height:100%;border-radius:50%;object-fit:cover;">
             {% else %}
                 {{ username[0].upper() if username }}

--- a/templates/ranking.html
+++ b/templates/ranking.html
@@ -39,7 +39,16 @@
                         {% for user in ranking_data %}
                         <tr>
                             <td>{{ loop.index }}</td>
-                            <td>{{ user.username }}</td>
+                            <td>
+                                <div class="ranking-user">
+                                    {% if user.avatar_url %}
+                                        <img src="{{ user.avatar_url }}" class="user-avatar-small" alt="{{ user.username }}">
+                                    {% else %}
+                                        <div class="user-avatar-small user-avatar-fallback">{{ user.username[0]|upper }}</div>
+                                    {% endif %}
+                                    <span>{{ user.username }}</span>
+                                </div>
+                            </td>
                             <td>{{ user.total_calories }}</td>
                             <td>{{ user.total_sessions }}</td>
                         </tr>


### PR DESCRIPTION
This PR adds user profile pictures to the ranking page, friend search results, pending friend requests, the friend list, and shared session displays so users are easier to identify across the app.

It reuses the existing avatar upload field from user accounts and returns avatar URLs through the relevant user/friend API responses. When a user does not have an uploaded profile picture, or when the saved avatar file is missing locally, the interface now falls back to a circular initial avatar instead of showing a broken image.

The change also adds shared avatar styling so the ranking table, account friend UI, and forum shared-session cards display user identity consistently.
