### PR TITLE
Add CSRF protection across forms and POST requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,8 @@ from email.message import EmailMessage
 from flask import Flask, render_template, request, redirect, url_for, jsonify, session, abort
 from flask_login import LoginManager, login_user, logout_user, login_required, current_user
 from flask_migrate import Migrate
+from flask_wtf import CSRFProtect
+from flask_wtf.csrf import CSRFError
 from models import db, ExerciseSession, SessionExercise, User, Share, Friend, AIFeedback
 from data import exercise_data
 from utils import calculate_calories, generateAiFeedbackText, getStartWeek, buildFeedback, buildFeedbackHash
@@ -36,9 +38,17 @@ app.config['MAX_CONTENT_LENGTH'] = 5 * 1024 * 1024
 
 db.init_app(app) #attach SQLAlchemy to Flask app
 
+csrf = CSRFProtect(app)
 migrate = Migrate(app, db) #set up Flask-Migrate for database migrations
 login_manager = LoginManager(app) #set up Flask-Login for user session management
 login_manager.login_view = 'login' #redirect to login page if user tries to access protected routes
+
+
+@app.errorhandler(CSRFError)
+def handle_csrf_error(error):
+    if request.is_json or request.path.startswith("/api/") or request.path == "/dashboard/ai-feedback":
+        return jsonify({"error": "Invalid or missing CSRF token"}), 400
+    return render_template("csrf_error.html", reason=error.description), 400
 
 def parse_location_fields(latitude_raw, longitude_raw):
     if not latitude_raw and not longitude_raw:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ Flask
 Flask-Login
 Flask-Migrate
 Flask-SQLAlchemy
+Flask-WTF
 python-dotenv
 openai
 anthropic

--- a/templates/account.html
+++ b/templates/account.html
@@ -93,6 +93,7 @@
 
 <form method="POST" action="/account" enctype="multipart/form-data" id="editSection" class="account-collapsible-form">
 
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 <input type="hidden" name="form_type" value="update_profile">
 
 <label>Date of Birth</label>
@@ -150,6 +151,7 @@
 
 <form method="POST" id="passwordSection" class="account-collapsible-form">
 
+<input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 <input type="hidden" name="form_type" value="change_password">
 
 <label>New Password</label>
@@ -221,6 +223,11 @@
 
 {% block scripts %}
 <script>
+const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute("content");
+const csrfJsonHeaders = {
+    "Content-Type": "application/json",
+    "X-CSRFToken": csrfToken
+};
 
 /* ================= PROFILE ================= */
 function toggleEdit(){
@@ -406,7 +413,7 @@ list.forEach(u=>{
 function addFriend(username, button){
 fetch('/api/add_friend',{
 method:'POST',
-headers:{'Content-Type':'application/json'},
+headers:csrfJsonHeaders,
 body:JSON.stringify({username:username})
 })
 .then(res => res.json())
@@ -459,7 +466,7 @@ box.appendChild(row);
 function acceptFriend(username){
 fetch('/api/accept_friend',{
 method:'POST',
-headers:{'Content-Type':'application/json'},
+headers:csrfJsonHeaders,
 body:JSON.stringify({username:username})
 })
 .then(()=>loadFriends());
@@ -468,7 +475,7 @@ body:JSON.stringify({username:username})
 function rejectFriend(username){
 fetch('/api/reject_friend',{
 method:'POST',
-headers:{'Content-Type':'application/json'},
+headers:csrfJsonHeaders,
 body:JSON.stringify({username:username})
 })
 .then(()=>loadFriends());
@@ -490,7 +497,7 @@ if(!confirm("Are you sure you want to delete this friend?")) return;
 
 fetch('/api/delete_friend',{
 method:'POST',
-headers:{'Content-Type':'application/json'},
+headers:csrfJsonHeaders,
 body:JSON.stringify({username:username})
 })
 .then(res=>res.json())

--- a/templates/base.html
+++ b/templates/base.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Exercise Planner{% endblock %}</title>
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
     {% block head %}{% endblock %}

--- a/templates/csrf_error.html
+++ b/templates/csrf_error.html
@@ -1,0 +1,23 @@
+{% extends "base.html" %}
+
+{% block title %}Invalid Request{% endblock %}
+
+{% block navbar %}
+    <div class="login-navbar">
+        <img src="{{ url_for('static', filename='images/logo.png') }}" alt="Exercise Planner">
+    </div>
+{% endblock %}
+
+{% block content %}
+<div class="container py-4">
+    <div class="main-box">
+        <h1>Invalid Request</h1>
+        <div class="alert alert-danger">
+            This form could not be submitted securely. Please refresh the page and try again.
+        </div>
+        {% if reason %}
+            <p class="text-muted">{{ reason }}</p>
+        {% endif %}
+    </div>
+</div>
+{% endblock %}

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -277,6 +277,7 @@
     //AI feedback button
     const aiFeedbackBtn = document.getElementById("generateAiFeedbackBtn");
     const aiFeedbackBox = document.getElementById("aiFeedbackBox");
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').getAttribute("content");
 
     if (aiFeedbackBtn && aiFeedbackBox) {
       aiFeedbackBtn.addEventListener("click", async () => {
@@ -286,7 +287,10 @@
 
         try {
           const response = await fetch("{{ url_for('dashAiFeedback') }}", {
-            method: "POST"
+            method: "POST",
+            headers: {
+              "X-CSRFToken": csrfToken
+            }
           });
 
           const data = await response.json();

--- a/templates/exercise.html
+++ b/templates/exercise.html
@@ -14,6 +14,7 @@
   <!-- main content -->
   <div class="container py-4">
     <form class="main-box" method="POST" action="{{ url_for('exercise') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
       <h1>Add Session</h1>
 
       {% if message %}
@@ -114,6 +115,7 @@
               <button type = "button" class = "btn-close" data-bs-dismiss = "modal"></button>
             </div>
             <form method = "POST" action = "{{url_for('forum')}}">
+              <input type = "hidden" name = "csrf_token" value = "{{ csrf_token() }}">
               <input type = "hidden" name = "action" value = "share">
               <input type = "hidden" name = "session_id" value = "{{new_session_id}}">
               <div class = "modal-body">

--- a/templates/forgot_password.html
+++ b/templates/forgot_password.html
@@ -41,6 +41,7 @@
         {% endif %}
 
         <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
             <!-- Email -->
             <div class="mb-3">

--- a/templates/forum.html
+++ b/templates/forum.html
@@ -112,6 +112,7 @@
                             </div>
                         </div>
                         <form method = "POST" action ="{{url_for('forum')}}">
+                            <input type = "hidden" name = "csrf_token" value = "{{ csrf_token() }}">
                             <input type = "hidden" name = "share_id" value = "{{share.id}}">
                             <button class = "like-btn {{ 'liked' if share.liked }}" type = "submit"> ❤️ </button>
                         </form>

--- a/templates/history.html
+++ b/templates/history.html
@@ -67,6 +67,7 @@
                                         Share
                                     </button>
                                     <form method="POST" action="{{ url_for('delete_session', session_id=session.id) }}" onsubmit="return confirm('Delete this session?');">
+                                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                                         <button type="submit" class="btn btn-outline-danger btn-sm">Delete</button>
                                     </form>
                                 </div>
@@ -85,6 +86,7 @@
                             <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                         </div>
                         <form method="POST" action="{{ url_for('forum') }}">
+                            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                             <input type="hidden" name="action" value="share">
                             <input type="hidden" name="session_id" id="historyShareSessionId">
                             <div class="modal-body">

--- a/templates/login.html
+++ b/templates/login.html
@@ -37,6 +37,7 @@
             {% endif %}
 
             <form method="POST" action="{{ url_for('login') }}">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
                 <label for="username">Username</label>
                 <input id="username" class="app-input" type="text" name="username" required>
 

--- a/templates/signup.html
+++ b/templates/signup.html
@@ -24,6 +24,7 @@
         {% endif %}
 
         <form method="POST">
+            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
             <!-- Username -->
             <div class="mb-3">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,6 +20,7 @@ flask_app.config.update(
     TESTING=True,
     MAIL_USERNAME="test@example.com",
     MAIL_PASSWORD="test-password",
+    WTF_CSRF_ENABLED=False,
 )
 
 

--- a/tests/test_flask_flows.py
+++ b/tests/test_flask_flows.py
@@ -1,4 +1,5 @@
 from datetime import date
+import re
 
 from models import db, ExerciseSession, SessionExercise, User
 from tests.conftest import create_user, login
@@ -66,6 +67,59 @@ def test_login_logout_and_protected_pages(client, app):
     response = client.get("/logout", follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["Location"].endswith("/login")
+
+
+def test_csrf_protects_post_forms_when_enabled(client, app):
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        with app.app_context():
+            create_user(username="csrfuser", email="csrf@example.com", password="Validpass123!")
+
+        response = client.post(
+            "/login",
+            data={"username": "csrfuser", "password": "Validpass123!"},
+        )
+        assert response.status_code == 400
+        assert b"securely" in response.data or b"CSRF" in response.data
+
+        login_page = client.get("/login")
+        token_match = re.search(
+            rb'name="csrf_token" value="([^"]+)"',
+            login_page.data,
+        )
+        assert token_match is not None
+
+        response = client.post(
+            "/login",
+            data={
+                "username": "csrfuser",
+                "password": "Validpass123!",
+                "csrf_token": token_match.group(1).decode(),
+            },
+            follow_redirects=False,
+        )
+        assert response.status_code == 302
+        assert response.headers["Location"].endswith("/dashboard")
+
+        response = client.post("/dashboard/ai-feedback")
+        assert response.status_code == 400
+        assert response.get_json()["error"] == "Invalid or missing CSRF token"
+
+        dashboard = client.get("/dashboard")
+        meta_match = re.search(
+            rb'<meta name="csrf-token" content="([^"]+)"',
+            dashboard.data,
+        )
+        assert meta_match is not None
+
+        response = client.post(
+            "/dashboard/ai-feedback",
+            headers={"X-CSRFToken": meta_match.group(1).decode()},
+        )
+        assert response.status_code == 400
+        assert response.get_json()["error"] != "Invalid or missing CSRF token"
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = False
 
 
 def test_exercise_session_is_saved_to_test_database(client, app):


### PR DESCRIPTION
This PR adds CSRF protection across the app using Flask-WTF. It enables `CSRFProtect` globally, adds CSRF tokens to all POST forms, and adds a shared CSRF meta token so JavaScript POST requests can send the token through the `X-CSRFToken` header.

The change covers login, signup, forgot password, exercise session creation, history delete/share forms, forum like/share forms, account profile/password forms, Dashboard AI feedback, and the friend-related JSON API requests. It also adds a CSRF error page for normal form submissions and JSON error responses for API/fetch requests.

I also updated the test configuration so existing tests can keep running normally, and added a focused CSRF regression test to confirm POST requests are rejected without a token and accepted when a valid token is included.

Testing completed: full pytest passed, Selenium tests passed, compileall passed, migration head check passed, and a manual web smoke test confirmed CSRF behavior across the main forms and JSON POST endpoints.
