### PR TITLE
Clean CSS comment encoding

### DIFF
--- a/static/css/dashboard.css
+++ b/static/css/dashboard.css
@@ -1,4 +1,4 @@
-/* ── Metric cards ────────────────────────────────────────── */
+/* Metric cards */
 .metric-card {
   background: #e0e0e0;
   border-radius: 12px;
@@ -26,7 +26,7 @@
   margin-top: 2px;
 }
 
-/* ── Calorie goal box ────────────────────────────────────── */
+/* Calorie goal box */
 .calorie-box {
   background: #e8e8e8;
   border-radius: 12px;
@@ -69,7 +69,7 @@
   width: 0;
 }
 
-/* ── Chart cards ─────────────────────────────────────────── */
+/* Chart cards */
 .chart-card {
   background: #e0e0e0;
   border-radius: 14px;

--- a/static/css/exercise.css
+++ b/static/css/exercise.css
@@ -14,7 +14,7 @@
 }
 
 
-/* ── Legacy page styles (index / exercise log pages) ─────── */
+/* Legacy page styles (index / exercise log pages) */
 .top-bar {
   background-color: #7793ae;
   padding: 10px 30px;

--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -1,12 +1,8 @@
-/* ============================================================
-   style.css �?all styles for Exercise Planner
-   Sections: base · navbar · layout · metric cards · calorie box
-             charts · map/history · utilities · auth pages
-             forum · dashboard · avatars · account
-   HTML files contain structure and Jinja only �?no inline styles
-   ============================================================ */
+/* Shared styles for Exercise Planner.
+   Sections: base, navbar, layout, utilities, avatars, and responsive rules.
+   HTML files contain structure and Jinja only; no inline styles. */
 
-/* ── Base ────────────────────────────────────────────────── */
+/* Base */
 body {
   background: #ffffff;
   font-family: Arial, sans-serif;
@@ -15,7 +11,7 @@ body {
   padding: 0;
 }
 
-/* ── Navbar ──────────────────────────────────────────────── */
+/* Navbar */
 .ep-navbar {
   border-bottom: 2px solid #5a7a96;
   padding: 10px 30px;
@@ -131,7 +127,7 @@ body {
   color: #333333;
 }
 
-/* Pink "Create Exercise" button �?always last in the navbar */
+/* Pink Create Exercise button, always last in the navbar */
 .ep-nav-link.create-btn {
   background: #e91e8c;
   color: #ffffff !important;
@@ -152,14 +148,14 @@ body {
   font-weight: 700;
 }
 
-/* ── Page layout ─────────────────────────────────────────── */
+/* Page layout */
 .page-content {
   max-width: 1000px;
   margin: 0 auto;
   padding: 1.75rem 1.25rem 3rem;
 }
 
-/* ── Utility ─────────────────────────────────────────────── */
+/* Utility */
 .text-pink  { color: #e91e8c; }
 .btn-pink {
   background: #e91e8c;
@@ -275,7 +271,7 @@ body {
   margin-top: 0.35rem;
 }
 
-/* ── Form validation rule indicators ─────────────────────── */
+/* Form validation rule indicators */
 .rule-invalid { color: #dc3545; }
 .rule-valid   { color: #198754; }
 

--- a/static/css/shares.css
+++ b/static/css/shares.css
@@ -66,7 +66,7 @@
 .add-record-btn {
   width: 100%;
 }
-/* ── Shares page ──────────────────────────────────────────── */
+/* Shares page */
 .shares-layout {
   min-height: calc(100vh - 90px);
 }


### PR DESCRIPTION
Fixed this now. The garbled CSS comments came from the earlier CSS split/encoding cleanup, so I replaced those comment separators with plain ASCII comments only. No styling rules were changed. I also checked the CSS files again and there are no remaining non-ASCII/garbled comment characters.