### PR TITLE
Add ranking page specific styles

### DIFF
--- a/static/css/ranking.css
+++ b/static/css/ranking.css
@@ -1,2 +1,54 @@
-/* Ranking page specific styles can live here when needed. */
+/* Ranking page */
+
+.ranking-filter-bar {
+  align-items: center;
+}
+
+.ranking-filter-bar .btn {
+  min-width: 5.5rem;
+}
+
+.ranking-results-note {
+  margin-bottom: 1rem;
+}
+
+.ranking-table {
+  min-width: 680px;
+}
+
+.ranking-table th:first-child,
+.ranking-table td:first-child {
+  width: 72px;
+  white-space: nowrap;
+}
+
+.ranking-table th,
+.ranking-table td {
+  padding: 0.85rem 0.75rem;
+}
+
+.ranking-user {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  min-width: 0;
+}
+
+.ranking-user span {
+  overflow-wrap: anywhere;
+}
+
+.ranking-empty-state {
+  margin-top: 0.5rem;
+}
+
+@media (max-width: 576px) {
+  .ranking-filter-bar .btn {
+    flex: 1 1 calc(50% - 0.5rem);
+  }
+
+  .ranking-table {
+    min-width: 620px;
+  }
+}
 

--- a/static/css/shared.css
+++ b/static/css/shared.css
@@ -279,7 +279,6 @@ body {
   font-weight: 700;
 }
 
-.ranking-user,
 .shared-user-line,
 .account-user-line {
   display: flex;

--- a/templates/ranking.html
+++ b/templates/ranking.html
@@ -17,7 +17,7 @@
             <p class="text-muted">Compare users by total calories burned from saved exercise sessions.</p>
             <hr>
 
-            <div class="d-flex flex-wrap gap-2 mb-3">
+            <div class="ranking-filter-bar d-flex flex-wrap gap-2 mb-3">
                 {% for value, option in period_options.items() %}
                     <a href="{{ url_for('ranking', period=value) }}"
                        class="btn btn-sm {{ 'btn-primary' if selected_period == value else 'btn-outline-primary' }}">
@@ -26,11 +26,11 @@
                 {% endfor %}
             </div>
 
-            <p class="text-muted">Showing {{ period_label|lower }} results. Users with no sessions in this period are placed after users with saved session data.</p>
+            <p class="ranking-results-note text-muted">Showing {{ period_label|lower }} results. Users with no sessions in this period are placed after users with saved session data.</p>
 
             {% if ranking_data %}
             <div class="table-responsive">
-                <table class="table table-striped align-middle">
+                <table class="table table-striped align-middle ranking-table">
                     <thead>
                         <tr>
                             <th>Rank</th>
@@ -61,7 +61,7 @@
                 </table>
             </div>
             {% else %}
-            <div class="alert alert-info mb-0">
+            <div class="alert alert-info ranking-empty-state mb-0">
                 No users have workout data yet.
             </div>
             {% endif %}


### PR DESCRIPTION
This PR adds real page-specific CSS for the Ranking page instead of leaving `ranking.css` as an empty placeholder.

The update keeps the existing layout and behaviour, but moves the ranking user row styling into `ranking.css`, adds a dedicated filter button bar style, fixes the Rank column width, improves table spacing, and adds small-screen table/filter handling so the ranking page stays stable on mobile.

I tested the change locally. All tests passed, and I also opened the Ranking page in a real browser to confirm `ranking.css` loads, the table renders correctly, the filter buttons display properly, and there are no severe console errors.
